### PR TITLE
Fix: Improve compatibility with other operating systems

### DIFF
--- a/.github/workflows/new-changes-validation.yml
+++ b/.github/workflows/new-changes-validation.yml
@@ -6,9 +6,6 @@ on:
       - 'main'
   pull_request:
 
-env:
-  WORK_PATH: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/
-
 jobs:
   cache-V:
     runs-on: ubuntu-latest
@@ -17,12 +14,12 @@ jobs:
       # and you need the latest commit of V most of the time, we always use the latest V version from the master branch
       # and getting it from the cache on the start of a job is not possible (because you need to know a version of V to cache it).
       # This step should be uncommented when Vlang will be stable and caching will be possible.
-#      - name: Check if V is cached
-#        id: check-v-cache
-#        uses: actions/cache/restore@v3
-#        with:
-#          path: ${{ env.WORK_PATH }}vlang/
-#          key: vlang-0.3.3-weekly.2023.08
+      # - name: Check if V is cached
+      #   id: check-v-cache
+      #   uses: actions/cache/restore@v3
+      #   with:
+      #     path: vlang
+      #     key: vlang-0.3.3-weekly.2023.08
 
       - name: Install V
         id: install-v
@@ -36,8 +33,8 @@ jobs:
       - name: Cache Vlang
         uses: actions/cache/save@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
 
   simple-build:
     needs: cache-V
@@ -50,8 +47,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -72,8 +69,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -95,8 +92,8 @@ jobs:
         id: check-llvm-cache
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}llvm
-          key: llvm-15
+          path: llvm
+          key: ${{ runner.os }}-llvm-15
 
       - if: ${{ steps.check-llvm-cache.outputs.cache-hit != 'true' }}
         name: Install LLVM and Clang
@@ -108,8 +105,8 @@ jobs:
         name: Cache LLVM and Clang
         uses: actions/cache/save@v3
         with:
-          path: ${{ env.WORK_PATH }}llvm
-          key: llvm-15
+          path: llvm
+          key: ${{ runner.os }}-llvm-15
 
   different-compilers:
     needs: cache-clang
@@ -124,8 +121,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -143,8 +140,8 @@ jobs:
         name: Restore LLVM and Clang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}llvm
-          key: llvm-15
+          path: llvm
+          key: ${{ runner.os }}-llvm-15
           fail-on-cache-miss: true
 
       - if: ${{ matrix.compiler == 'clang' }}
@@ -170,8 +167,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -182,7 +179,7 @@ jobs:
       - name: Restore LLVM and Clang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}llvm
+          path: llvm
           key: llvm-15
           fail-on-cache-miss: true
 
@@ -208,8 +205,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -235,8 +232,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -262,8 +259,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -283,14 +280,14 @@ jobs:
         run: v -cc gcc -cflags -fsanitize=undefined -cflags -fsanitize=shift -cflags -fsanitize=shift-exponent -cflags -fsanitize=shift-base -cflags -fsanitize=integer-divide-by-zero -cflags -fsanitize=unreachable -cflags -fsanitize=vla-bound -cflags -fsanitize=null -cflags -fsanitize=return -cflags -fsanitize=signed-integer-overflow -cflags -fsanitize=bounds -cflags -fsanitize=bounds-strict -cflags -fsanitize=alignment -cflags -fsanitize=object-size -cflags -fsanitize=float-divide-by-zero -cflags -fsanitize=float-cast-overflow -cflags -fsanitize=nonnull-attribute -cflags -fsanitize=returns-nonnull-attribute -cflags -fsanitize=bool -cflags -fsanitize=enum -cflags -fsanitize=vptr -cflags -fsanitize=pointer-overflow -cflags -fsanitize=builtin test .
 
   vab-compilation:
-    needs: [clang-sanitizers, gcc-sanitizers, gcc-address-sanitizers, gcc-undefined-sanitizers]
+    needs: [ clang-sanitizers, gcc-sanitizers, gcc-address-sanitizers, gcc-undefined-sanitizers ]
     runs-on: ubuntu-latest
     steps:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -330,8 +327,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -357,8 +354,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -379,8 +376,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V
@@ -404,8 +401,8 @@ jobs:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
         with:
-          path: ${{ env.WORK_PATH }}vlang/
-          key: vlang-${{ env.V_VERSION }}
+          path: vlang
+          key: ${{ runner.os }}-vlang-${{ env.V_VERSION }}
           fail-on-cache-miss: true
 
       - name: Install V


### PR DESCRIPTION
I was doing quite some CI work in recent projects - lot of V things as well. There were some new insights, so I thought to just submit some of them and you can merge them here as well if you like.

The work path we replaced in this PR with the env variable: https://github.com/ArtemkaKun/v-project-basement/pull/1/files is just the default "home" path of the workflow so it's not necessary to specify - at least on gnu and unix systems it's the default path. When extending workflows to e.g. Windows it becomes a disadvantage having it specified as it starts making problems.

The changes also add the runner.os to the cache key.