### PR TITLE
Fix: Use array type for issue form labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,6 @@
 name: 🐛 Bug Report
 description: Report a bug
-title: (bug report summary)
-labels: Bug
+labels: [bug]
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,6 @@
 name: 🚀 Feature Request
 description: Suggest an idea for this project
-title: (feature request summary)
-labels: Feature Request
+labels: [enhancement]
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
Currently, the issue templates won't add the labels that are set.

Changes:
- `label` wants an array as value, so we give it one. 
- The workflow won't create labels if they are not present. So it's be considered to change the 
non-default `Bug` and `Feature Request` labels to default labels `bug` and `enhancement` to have something more "batteries included".
- It removes the preset title to make it mandatory for a user to think about and write a title for an issue as it can't be submitted without. We had some occurrences at V where `(bug report summary)` was just submitted, this would reduce such things.

I realize that should have split the changes into smaller chunks. Let me know if only parts are of interest then I'll rebase accordingly.