### PR TITLE
Fix: Use empty string instead of null in matrix configurations

### DIFF
--- a/.github/workflows/new-changes-validation.yml
+++ b/.github/workflows/new-changes-validation.yml
@@ -44,8 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        trimming: [ null , -skip-unused ]
-        memory-management: [ null , -autofree ]
+        trimming: [ '', -skip-unused ]
+        memory-management: [ '', -autofree ]
     steps:
       - name: Restore Vlang
         uses: actions/cache/restore@v3
@@ -117,9 +117,9 @@ jobs:
     strategy:
       matrix:
         compiler: [ gcc, clang ]
-        trimming: [ null , -skip-unused ]
-        memory-management: [ null , -autofree ]
-        optimization: [ null , -prod ]
+        trimming: [ '', -skip-unused ]
+        memory-management: [ '', -autofree ]
+        optimization: [ '', -prod ]
     steps:
       - name: Restore Vlang
         uses: actions/cache/restore@v3


### PR DESCRIPTION
This is just small fix of yamlls complaining about a type error. 

![Screenshot from 2023-07-26 23-02-30](https://github.com/ArtemkaKun/v-project-basement/assets/34311583/7b7bc15f-9722-4126-94db-cb4721a62438)

Technically the current usage of `null` works.